### PR TITLE
Update name for no-ip.com ddns opkg

### DIFF
--- a/roles/ddns/tasks/main.yml
+++ b/roles/ddns/tasks/main.yml
@@ -9,7 +9,7 @@
     (openwrt_ddns_ipv4_service_name is defined and openwrt_ddns_ipv4_service_name == "no-ip.com")
     or (openwrt_ddns_ipv6_service_name is defined and openwrt_ddns_ipv6_service_name == "no-ip.com")
   opkg:
-    name: ddns-scripts_no-ip_com
+    name: ddns-scripts-noip
     state: present
 
 - name: Start and enable ddns service


### PR DESCRIPTION
Looks like the name of the opkg for the no-ip.com ddns scripts changed.

```
root@OpenWrt:~# opkg list-installed |grep ddns|grep noip
ddns-scripts-noip - 2.8.2-25
root@OpenWrt:~# opkg list |grep ddns|grep no.*ip
ddns-scripts-noip - 2.8.2-25 - Dynamic DNS Client scripts extension for "no-ip.com".
```